### PR TITLE
Slow-start batch pod creation of rs, rc, ds, jobs

### DIFF
--- a/pkg/controller/daemon/BUILD
+++ b/pkg/controller/daemon/BUILD
@@ -25,6 +25,7 @@ go_library(
         "//plugin/pkg/scheduler/algorithm:go_default_library",
         "//plugin/pkg/scheduler/algorithm/predicates:go_default_library",
         "//plugin/pkg/scheduler/schedulercache:go_default_library",
+        "//plugin/pkg/scheduler/util:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/apps/v1beta1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/pkg/controller/job/BUILD
+++ b/pkg/controller/job/BUILD
@@ -16,6 +16,7 @@ go_library(
     deps = [
         "//pkg/controller:go_default_library",
         "//pkg/util/metrics:go_default_library",
+        "//plugin/pkg/scheduler/util:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/batch/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -124,6 +124,7 @@ func TestControllerSyncJob(t *testing.T) {
 		parallelism int32
 		completions int32
 		deleting    bool
+		podLimit    int
 
 		// pod setup
 		podControllerError error
@@ -141,94 +142,99 @@ func TestControllerSyncJob(t *testing.T) {
 		expectedComplete  bool
 	}{
 		"job start": {
-			2, 5, false,
+			2, 5, false, 0,
 			nil, 0, 0, 0, 0,
 			2, 0, 2, 0, 0, false,
 		},
 		"WQ job start": {
-			2, -1, false,
+			2, -1, false, 0,
 			nil, 0, 0, 0, 0,
 			2, 0, 2, 0, 0, false,
 		},
 		"pending pods": {
-			2, 5, false,
+			2, 5, false, 0,
 			nil, 2, 0, 0, 0,
 			0, 0, 2, 0, 0, false,
 		},
 		"correct # of pods": {
-			2, 5, false,
+			2, 5, false, 0,
 			nil, 0, 2, 0, 0,
 			0, 0, 2, 0, 0, false,
 		},
 		"WQ job: correct # of pods": {
-			2, -1, false,
+			2, -1, false, 0,
 			nil, 0, 2, 0, 0,
 			0, 0, 2, 0, 0, false,
 		},
 		"too few active pods": {
-			2, 5, false,
+			2, 5, false, 0,
 			nil, 0, 1, 1, 0,
 			1, 0, 2, 1, 0, false,
 		},
 		"too few active pods with a dynamic job": {
-			2, -1, false,
+			2, -1, false, 0,
 			nil, 0, 1, 0, 0,
 			1, 0, 2, 0, 0, false,
 		},
 		"too few active pods, with controller error": {
-			2, 5, false,
+			2, 5, false, 0,
 			fmt.Errorf("Fake error"), 0, 1, 1, 0,
 			1, 0, 1, 1, 0, false,
 		},
 		"too many active pods": {
-			2, 5, false,
+			2, 5, false, 0,
 			nil, 0, 3, 0, 0,
 			0, 1, 2, 0, 0, false,
 		},
 		"too many active pods, with controller error": {
-			2, 5, false,
+			2, 5, false, 0,
 			fmt.Errorf("Fake error"), 0, 3, 0, 0,
 			0, 1, 3, 0, 0, false,
 		},
 		"failed pod": {
-			2, 5, false,
+			2, 5, false, 0,
 			nil, 0, 1, 1, 1,
 			1, 0, 2, 1, 1, false,
 		},
 		"job finish": {
-			2, 5, false,
+			2, 5, false, 0,
 			nil, 0, 0, 5, 0,
 			0, 0, 0, 5, 0, true,
 		},
 		"WQ job finishing": {
-			2, -1, false,
+			2, -1, false, 0,
 			nil, 0, 1, 1, 0,
 			0, 0, 1, 1, 0, false,
 		},
 		"WQ job all finished": {
-			2, -1, false,
+			2, -1, false, 0,
 			nil, 0, 0, 2, 0,
 			0, 0, 0, 2, 0, true,
 		},
 		"WQ job all finished despite one failure": {
-			2, -1, false,
+			2, -1, false, 0,
 			nil, 0, 0, 1, 1,
 			0, 0, 0, 1, 1, true,
 		},
 		"more active pods than completions": {
-			2, 5, false,
+			2, 5, false, 0,
 			nil, 0, 10, 0, 0,
 			0, 8, 2, 0, 0, false,
 		},
 		"status change": {
-			2, 5, false,
+			2, 5, false, 0,
 			nil, 0, 2, 2, 0,
 			0, 0, 2, 2, 0, false,
 		},
 		"deleting job": {
-			2, 5, true,
+			2, 5, true, 0,
 			nil, 1, 1, 1, 0,
 			0, 0, 2, 1, 0, false,
+		},
+		"limited pods": {
+			100, 200, false, 10,
+			nil, 0, 0, 0, 0,
+			10, 0, 10, 0, 0, false,
 		},
 	}
 
@@ -236,7 +242,7 @@ func TestControllerSyncJob(t *testing.T) {
 		// job manager setup
 		clientset := clientset.NewForConfigOrDie(&restclient.Config{Host: "", ContentConfig: restclient.ContentConfig{GroupVersion: &api.Registry.GroupOrDie(v1.GroupName).GroupVersion}})
 		manager, sharedInformerFactory := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
-		fakePodControl := controller.FakePodControl{Err: tc.podControllerError}
+		fakePodControl := controller.FakePodControl{Err: tc.podControllerError, CreateLimit: tc.podLimit}
 		manager.podControl = &fakePodControl
 		manager.podStoreSynced = alwaysReady
 		manager.jobStoreSynced = alwaysReady
@@ -276,7 +282,7 @@ func TestControllerSyncJob(t *testing.T) {
 				t.Errorf("%s: Syncing jobs would return error when podController exception", name)
 			}
 		} else {
-			if err != nil {
+			if err != nil && (tc.podLimit == 0 || fakePodControl.CreateCallCount < tc.podLimit) {
 				t.Errorf("%s: unexpected error when syncing jobs %v", name, err)
 			}
 		}
@@ -326,6 +332,10 @@ func TestControllerSyncJob(t *testing.T) {
 		// validate conditions
 		if tc.expectedComplete && !getCondition(actual, batch.JobComplete) {
 			t.Errorf("%s: expected completion condition.  Got %#v", name, actual.Status.Conditions)
+		}
+		// validate slow start
+		if tc.podLimit > 0 && fakePodControl.CreateCallCount > tc.podLimit*2 {
+			t.Errorf("%s: Unexpected number of create calls.  Expected <= %d, saw %d\n", name, fakePodControl.CreateLimit*2, fakePodControl.CreateCallCount)
 		}
 	}
 }

--- a/pkg/controller/replicaset/BUILD
+++ b/pkg/controller/replicaset/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//pkg/api/v1/pod:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/util/metrics:go_default_library",
+        "//plugin/pkg/scheduler/util:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",

--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -47,6 +47,7 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/util/metrics"
+	schedutil "k8s.io/kubernetes/plugin/pkg/scheduler/util"
 )
 
 const (
@@ -450,41 +451,53 @@ func (rsc *ReplicaSetController) manageReplicas(filteredPods []*v1.Pod, rs *exte
 		// beforehand and store it via ExpectCreations.
 		rsc.expectations.ExpectCreations(rsKey, diff)
 		var wg sync.WaitGroup
-		wg.Add(diff)
 		glog.V(2).Infof("Too few %q/%q replicas, need %d, creating %d", rs.Namespace, rs.Name, *(rs.Spec.Replicas), diff)
-		for i := 0; i < diff; i++ {
-			go func() {
-				defer wg.Done()
-				var err error
-				boolPtr := func(b bool) *bool { return &b }
-				controllerRef := &metav1.OwnerReference{
-					APIVersion:         controllerKind.GroupVersion().String(),
-					Kind:               controllerKind.Kind,
-					Name:               rs.Name,
-					UID:                rs.UID,
-					BlockOwnerDeletion: boolPtr(true),
-					Controller:         boolPtr(true),
-				}
-				err = rsc.podControl.CreatePodsWithControllerRef(rs.Namespace, &rs.Spec.Template, rs, controllerRef)
-				if err != nil && errors.IsTimeout(err) {
-					// Pod is created but its initialization has timed out.
-					// If the initialization is successful eventually, the
-					// controller will observe the creation via the informer.
-					// If the initialization fails, or if the pod keeps
-					// uninitialized for a long time, the informer will not
-					// receive any update, and the controller will create a new
-					// pod when the expectation expires.
-					return
-				}
-				if err != nil {
-					// Decrement the expected number of creates because the informer won't observe this pod
-					glog.V(2).Infof("Failed creation, decrementing expectations for replica set %q/%q", rs.Namespace, rs.Name)
-					rsc.expectations.CreationObserved(rsKey)
-					errCh <- err
-				}
-			}()
+		skippedPods := schedutil.SlowStart(diff, func(batchSize, _ int) int {
+			errorCount := len(errCh)
+			wg.Add(batchSize)
+			for i := 0; i < batchSize; i++ {
+				go func() {
+					defer wg.Done()
+					var err error
+					boolPtr := func(b bool) *bool { return &b }
+					controllerRef := &metav1.OwnerReference{
+						APIVersion:         controllerKind.GroupVersion().String(),
+						Kind:               controllerKind.Kind,
+						Name:               rs.Name,
+						UID:                rs.UID,
+						BlockOwnerDeletion: boolPtr(true),
+						Controller:         boolPtr(true),
+					}
+					err = rsc.podControl.CreatePodsWithControllerRef(rs.Namespace, &rs.Spec.Template, rs, controllerRef)
+					if err != nil && errors.IsTimeout(err) {
+						// Pod is created but its initialization has timed out.
+						// If the initialization is successful eventually, the
+						// controller will observe the creation via the informer.
+						// If the initialization fails, or if the pod keeps
+						// uninitialized for a long time, the informer will not
+						// receive any update, and the controller will create a new
+						// pod when the expectation expires.
+						return
+					}
+					if err != nil {
+						// Decrement the expected number of creates because the informer won't observe this pod
+						glog.V(2).Infof("Failed creation, decrementing expectations for replica set %q/%q", rs.Namespace, rs.Name)
+						rsc.expectations.CreationObserved(rsKey)
+						errCh <- err
+					}
+				}()
+			}
+			wg.Wait()
+			return len(errCh) - errorCount
+		})
+		// any skipped pods that we never attempted to start shouldn't be expected.
+		if skippedPods > 0 {
+			glog.V(2).Infof("Slow-start failure. Skipping creation of %d pods, decrementing expectations for replica set %q/%q", skippedPods, rs.Namespace, rs.Name)
+			for i := 0; i < skippedPods; i++ {
+				// Decrement the expected number of creates because the informer won't observe this pod
+				rsc.expectations.CreationObserved(rsKey)
+			}
 		}
-		wg.Wait()
 	} else if diff > 0 {
 		if diff > rsc.burstReplicas {
 			diff = rsc.burstReplicas

--- a/pkg/controller/replication/BUILD
+++ b/pkg/controller/replication/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//pkg/api/v1/pod:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/util/metrics:go_default_library",
+        "//plugin/pkg/scheduler/util:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/pkg/controller/replication/replication_controller_test.go
+++ b/pkg/controller/replication/replication_controller_test.go
@@ -284,6 +284,26 @@ func TestSyncReplicationControllerCreates(t *testing.T) {
 	validateSyncReplication(t, &fakePodControl, 2, 0, 0)
 }
 
+// Tell the controller to create 100 replicas, but simulate a limit (like a quota limit)
+// of 10, and verify that the controller doesn't make 100 create calls per sync pass
+func TestSyncReplicationControllerCreateFailures(t *testing.T) {
+	fakePodControl := controller.FakePodControl{}
+	fakePodControl.CreateLimit = 10
+
+	rc := newReplicationController(fakePodControl.CreateLimit * 10)
+	c := fake.NewSimpleClientset(rc)
+	manager, _ /*podInformer*/, rcInformer := newReplicationManagerFromClient(c, BurstReplicas)
+
+	rcInformer.Informer().GetIndexer().Add(rc)
+
+	manager.podControl = &fakePodControl
+	manager.syncReplicationController(getKey(rc, t))
+	validateSyncReplication(t, &fakePodControl, fakePodControl.CreateLimit, 0, 0)
+	if fakePodControl.CreateCallCount > fakePodControl.CreateLimit*2 {
+		t.Errorf("Unexpected number of create calls.  Expected <= %d, saw %d\n", fakePodControl.CreateLimit*2, fakePodControl.CreateCallCount)
+	}
+}
+
 func TestStatusUpdatesWithoutReplicasChange(t *testing.T) {
 	// Setup a fake server to listen for requests, and run the rc manager in steady state
 	fakeHandler := utiltesting.FakeHandler{

--- a/plugin/pkg/scheduler/util/BUILD
+++ b/plugin/pkg/scheduler/util/BUILD
@@ -17,6 +17,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "backoff_utils.go",
+        "slowstart_utils.go",
         "testutil.go",
         "utils.go",
     ],
@@ -28,6 +29,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/client-go/util/integer:go_default_library",
     ],
 )
 

--- a/plugin/pkg/scheduler/util/slowstart_utils.go
+++ b/plugin/pkg/scheduler/util/slowstart_utils.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"k8s.io/client-go/util/integer"
+)
+
+// A StartFunc takes a batchSize and pos (position). The batchSize indicates
+// the number of start calls the StartFunc should issue and pos indicates the
+// number of previous start calls that have been previously issued by the
+// StartFunc during the controller's current sync cycle.  A StartFunc should
+// return the number of unsuccessful calls (<= batchSize)
+type StartFunc func(int, int) int
+
+// Batch a start operation such as the creation of pods. Batch sizes start at 1
+// and double with each successful iteration in a kind of "slow start".  This
+// handles attempts to perform large numbers of start operations that would
+// likely all fail with the same error. For example, a project with a low quota
+// that attempts to create a large number of pods will be prevented from
+// spamming the API service with the pod create requests after one of its pods
+// fails. Conveniently, this also prevents the event spam that those failures
+// would generate.  toStart is the total number of items that should be
+// started.  startFunc is a function that can perform the start operation.  The
+// return value is the number of skipped start operations as a result of a slow
+// start failure. In the case where all start operations succeeded, 0 is
+// returned. Otherwise the return value is the number of start attempts
+// subtracted from toStart.
+func SlowStart(toStart int, startFunc StartFunc) int {
+	for batchSize, pos := 1, 0; toStart > pos; batchSize, pos = integer.IntMin(2*batchSize, toStart-(pos+batchSize)), pos+batchSize {
+		// any skipped pods that we never attempted to start shouldn't be expected.
+		if startFunc(batchSize, pos) > 0 {
+			// The skipped pods will be retried later. The next controller resync will
+			// retry the slow start process.
+			return toStart - batchSize - pos
+		}
+	}
+	return 0
+}

--- a/plugin/pkg/scheduler/util/slowstart_utils_test.go
+++ b/plugin/pkg/scheduler/util/slowstart_utils_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"k8s.io/client-go/util/integer"
+	"testing"
+)
+
+func TestSlowStart(t *testing.T) {
+	tests := []struct {
+		name        string
+		total       int
+		limit       int
+		maxAttempts int
+	}{
+		{"med limit", 500, 31, 64},
+		{"low limit", 10, 1, 3},
+		{"high limit", 500, 400, 500},
+		{"no limit", 500, 500, 500},
+	}
+
+	for _, test := range tests {
+		attempts := 0
+		skipped := SlowStart(test.total, func(toStart, pos int) int {
+			if pos != attempts {
+				t.Errorf("expected pos: %d, got %d for %s", attempts, pos, test.name)
+			}
+			attempts += toStart
+			if attempts > test.limit {
+				return integer.IntMin(toStart, attempts-test.limit)
+			}
+			return 0
+		})
+		if attempts > test.maxAttempts {
+			t.Errorf("too many attempts made. expected: <=%d, got %d for %s", test.maxAttempts, attempts, test.name)
+		}
+		if attempts < test.limit {
+			t.Errorf("too few attempts made. expected: >=%d, got %d for %s", test.limit, attempts, test.name)
+		}
+		if skipped < test.total-test.maxAttempts {
+			t.Errorf("not enough pod starts skipped. expected: >=%d, got %d for %s", test.total-test.maxAttempts, skipped, test.name)
+		}
+	}
+}


### PR DESCRIPTION
Prevent too-large replicas from generating enormous numbers
of events by creating only a few pods at a time, then increasing
the batch size when pod creations succeed. Stop creating batches
of pods when any pod creation errors are encountered.

This alternate version has the common code factored out to the
SlowStart utility function.